### PR TITLE
fix: Calling `getNode()` on the ref of an Animated component

### DIFF
--- a/src/carousel.js
+++ b/src/carousel.js
@@ -64,7 +64,7 @@ class Carousel extends Component {
     onScrollEnd(data[index], index);
     this.currentIndex = index;
     setTimeout(() => {
-      this._scrollView.getNode().scrollToOffset({
+      this._scrollView.scrollToOffset({
         offset:
           index * (itemWidth + separatorWidth) +
           this.halfItemWidth -


### PR DESCRIPTION
#12